### PR TITLE
Refactor: movido AuthenticationService a carpeta impl

### DIFF
--- a/src/main/java/learning/platform/service/impl/AuthenticationService.java
+++ b/src/main/java/learning/platform/service/impl/AuthenticationService.java
@@ -6,6 +6,11 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+/**
+ * Implementación de UserDetailsService para Spring Security.
+ * Se utiliza internamente por AuthenticationManager para cargar usuarios desde la base.
+ */
+
 @Service
 public class AuthenticationService implements UserDetailsService {
 


### PR DESCRIPTION
Se reorganizó la clase `AuthenticationService` dentro de `service.impl` para seguir la convención de implementación de interfaces (`UserDetailsService`).  
No se modificó la lógica interna, solo la ubicación del archivo.  
Listo para revisión y merge a `develop`.
