### PR TITLE
Features/swagger configs created

### DIFF
--- a/src/main/java/learning/platform/config/SecurityConfiguration.java
+++ b/src/main/java/learning/platform/config/SecurityConfiguration.java
@@ -58,7 +58,7 @@ public class SecurityConfiguration {
                             .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                             .requestMatchers(HttpMethod.POST, "/api/auth/register").permitAll()
                             .requestMatchers(HttpMethod.GET, "/api/users/**").hasRole("ADMIN")
-                            .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll();
+                            .requestMatchers("/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/webjars/**", "/swagger-resources/**").permitAll();
                     req.anyRequest().authenticated();
                 }) .headers(headers -> headers
                         // activa X-Content-Type-Options

--- a/src/main/java/learning/platform/config/SwaggerConfig.java
+++ b/src/main/java/learning/platform/config/SwaggerConfig.java
@@ -1,23 +1,37 @@
-/*
 package learning.platform.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
+                // 🔹 Información de la API
                 .info(new Info()
-                        .title("E-learning Platform API")
+                        .title("Lumia API")
                         .version("1.0")
                         .description("Documentación de la API para la plataforma de aprendizaje electrónico")
                         .termsOfService("http://localhost:8080/terms")
-                        .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+                        .license(new License().name("Apache 2.0").url("http://springdoc.org")))
+                // 🔹 Requerimiento de seguridad global (JWT)
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                // 🔹 Definición del esquema de seguridad
+                .components(new Components()
+                        .addSecuritySchemes("Bearer Authentication",
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                                        .description("Introduce el token JWT con el formato: Bearer {token}")));
     }
 }
-*/

--- a/src/main/java/learning/platform/controller/AuthController.java
+++ b/src/main/java/learning/platform/controller/AuthController.java
@@ -3,6 +3,7 @@ package learning.platform.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import learning.platform.dto.AuthResponse;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
+@SecurityRequirement(name = "none")
 @Tag(name = "Autenticación", description = "Endpoints para registro y login de usuarios")
 public class AuthController {
 

--- a/src/main/java/learning/platform/controller/EnrollmentController.java
+++ b/src/main/java/learning/platform/controller/EnrollmentController.java
@@ -1,5 +1,11 @@
 package learning.platform.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import learning.platform.config.TokenService;
 import learning.platform.dto.EnrollmentRequest;
@@ -16,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/enrollment")
+@Tag(name = "Enrollments", description = "Operaciones para gestionar inscripciones de estudiantes a cursos")
 public class EnrollmentController {
 
     private final EnrollmentServiceImpl enrollmentService;
@@ -24,36 +31,47 @@ public class EnrollmentController {
         this.enrollmentService = enrollmentService;
     }
 
+    @Operation(summary = "Crear inscripción", description = "Inscribe a un estudiante en un curso")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Inscripción creada correctamente"),
+            @ApiResponse(responseCode = "400", description = "Datos inválidos"),
+    })
     @PostMapping("/create")
     public ResponseEntity<EnrollmentResponse> createEnrollment(@Valid @RequestBody EnrollmentRequest datos){
         var enrollment = enrollmentService.enrollStudent(datos);
         return ResponseEntity.ok(enrollment);
     }
 
+    @Operation(summary = "Completar inscripción", description = "Marca un curso como completado para el estudiante")
     @PutMapping("/complete/{enrollmentId}")
     public ResponseEntity<EnrollmentResponse> endEnrollment(@PathVariable Long enrollmentId){
         var erollment = enrollmentService.completeCourse(enrollmentId);
         return  ResponseEntity.ok(erollment);
     }
 
+    @Operation(summary = "Cancelar inscripción", description = "Cancela una inscripción existente")
     @PutMapping("/cancel/{enrollmentId}")
     public ResponseEntity<EnrollmentResponse> cancellEnrollment(@PathVariable Long enrollmentId){
         var erollment = enrollmentService.cancelCourse(enrollmentId);
         return  ResponseEntity.ok(erollment);
     }
 
+    @Operation(summary = "Mis inscripciones", description = "Obtiene todas las inscripciones del estudiante autenticado")
     @GetMapping("/my-enrollments")
     public ResponseEntity<Page<EnrollmentResponse>> allMyEnrolls(@AuthenticationPrincipal User user, Pageable pageable){
         return ResponseEntity.ok(enrollmentService.findByStudent(user.getId(), pageable));
     }
 
+    @Operation(summary = "Inscripciones de un curso", description = "Obtiene todas las inscripciones de un curso, accesible para instructores")
     @GetMapping("/course-enrollments")
     public ResponseEntity<Page<EnrollmentResponse>> courseEnrolls(@AuthenticationPrincipal User user, Pageable pageable){
         return ResponseEntity.ok(enrollmentService.findByCourse(user.getId(), pageable));
     }
 
+
+    @Operation(summary = "Eliminar inscripción", description = "Elimina una inscripción específica")
     @DeleteMapping("/{enrollmentId}")
-    public ResponseEntity delateEnrollment(@PathVariable Long enrollmentId){
+    public ResponseEntity delateEnrollment(@Parameter(description = "ID de la inscripción a eliminar") @PathVariable Long enrollmentId){
         enrollmentService.deleteEnrollment(enrollmentId);
         return ResponseEntity.ok(HttpStatus.ACCEPTED);
     }

--- a/src/main/java/learning/platform/controller/PaymentController.java
+++ b/src/main/java/learning/platform/controller/PaymentController.java
@@ -1,5 +1,10 @@
 package learning.platform.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import learning.platform.config.TokenService;
 import learning.platform.dto.PaymentRequest;
@@ -13,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/payment")
+@Tag(name = "Payments", description = "Operaciones para gestionar las subscripcioes de estudiantes a la plataforma")
 public class PaymentController {
 
     private final PaymentServiceImpl service;
@@ -21,21 +27,41 @@ public class PaymentController {
         this.service = service;
     }
 
+    @Operation(summary = "Crear un nuevo pago")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pago creado correctamente"),
+            @ApiResponse(responseCode = "400", description = "Solicitud inválida")
+    })
     @PostMapping
     public ResponseEntity<PaymentResponse> crearPago(@Valid @RequestBody PaymentRequest request){
         return ResponseEntity.ok(service.pay(request));
     }
 
+    @Operation(summary = "Actualizar el pago del usuario autenticado")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pago actualizado correctamente"),
+            @ApiResponse(responseCode = "400", description = "Solicitud Invalida")
+    })
     @PutMapping
     public  ResponseEntity<PaymentResponse> actualizarPago(@AuthenticationPrincipal User user){
         return ResponseEntity.ok(service.updatePayment(user.getId()));
     }
 
+    @Operation(summary = "Obtener los pagos del usuario autenticado")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pagos obtenidos correctamente"),
+            @ApiResponse(responseCode = "400", description = "Solicitud Invalida")
+    })
     @GetMapping("/my-payments")
     public  ResponseEntity<PaymentResponse> obtenerMisPagos(@AuthenticationPrincipal User user){
         return ResponseEntity.ok(service.getPayments(user.getId()));
     }
 
+    @Operation(summary = "Cancelar el pago del usuario autenticado")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "Pago cancelado correctamente"),
+            @ApiResponse(responseCode = "400", description = "Solicitud Invalida")
+    })
     @DeleteMapping
     public  ResponseEntity cancelarPago(@AuthenticationPrincipal User user){
         service.cancelTransaction(user.getId());

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -7,7 +7,7 @@ server.port=8080
 # Configuración de la base de datos
 spring.datasource.url=jdbc:postgresql://localhost:5432/elearning
 spring.datasource.username=postgres
-spring.datasource.password=password
+spring.datasource.password=java
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA / Hibernate

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -7,7 +7,7 @@ server.port=8080
 # Configuración de la base de datos
 spring.datasource.url=jdbc:postgresql://localhost:5432/elearning
 spring.datasource.username=postgres
-spring.datasource.password=java
+spring.datasource.password=password
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA / Hibernate

--- a/src/main/resources/db/migration/V10__create_notification_events.sql
+++ b/src/main/resources/db/migration/V10__create_notification_events.sql
@@ -1,7 +1,8 @@
 CREATE TABLE notification_events (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     notification_type VARCHAR(50) NOT NULL CHECK (
-        notification_type IN ('NEW_CHAT_MESSAGE', 'NEW_ASSIGNMENT', 'SYSTEM_ALERT', 'GRADE_POSTED')
+        notification_type IN ('NEW_CHAT_MESSAGE', 'NEW_ASSIGNMENT', 'SYSTEM_ALERT',
+        'GRADE_POSTED','NOTIF_STUDENTS', 'NOTIF_GENERAL', 'NOTIF_INSTRUCTORS')
     ),
     related_id BIGINT,
     content TEXT,

--- a/src/main/resources/db/migration/V6__create-table-progress.sql
+++ b/src/main/resources/db/migration/V6__create-table-progress.sql
@@ -2,7 +2,10 @@ CREATE TABLE progress(
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     enrollment_id BIGINT NOT NULL,
     lesson_id BIGINT NOT NULL,
+    score INTEGER,
     completion_percentage NUMERIC (5,2) DEFAULT 0.00,
+    completed BOOLEAN NOT NULL DEFAULT false,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT fk_enrollment
         FOREIGN KEY (enrollment_id) REFERENCES enrollments(id)


### PR DESCRIPTION
## Descripción

Se añadieron anotaciones de Swagger/OpenAPI a los controladores **PaymentController** y **EnrollmentController** para mejorar la documentación de la API. Ahora los endpoints muestran claramente los requisitos de seguridad (JWT) y las posibles respuestas.

## Cambios realizados

* Se añadieron anotaciones `@Operation` y `@ApiResponses` en los endpoints de **PaymentController**.
* Se documentaron los endpoints de **EnrollmentController** con descripciones y códigos de respuesta esperados.

## Cómo probarlo

1. Levantar el proyecto.
2. Acceder a la documentación en `http://localhost:8080/swagger-ui.html`.
3. Revisar que los endpoints de **Payment** y **Enrollment** muestren:

   * Títulos y descripciones claras.
   * Requisitos de autenticación JWT.

