### PR TITLE
fix - Seguridad y CORS

### DIFF
--- a/src/main/java/learning/platform/config/CorsConfig.java
+++ b/src/main/java/learning/platform/config/CorsConfig.java
@@ -2,27 +2,33 @@ package learning.platform.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class CorsConfig {
 
     @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins(
-                                "http://localhost:3000",
-                                "http://localhost:9002",
-                                "https://front-e-learning-seven.vercel.app" // 🔑 producción en Vercel
-                        )
-                        .allowedMethods("GET","POST","PUT","DELETE","OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true);
-            }
-        };
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        // Orígenes exactos si allowCredentials = true
+        config.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000",
+                "http://localhost:9002",
+                "https://front-e-learning-seven.vercel.app"
+        ));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        // aplica a todas las rutas del backend
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/learning/platform/config/SecurityConfiguration.java
+++ b/src/main/java/learning/platform/config/SecurityConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
@@ -32,6 +33,8 @@ public class SecurityConfiguration {
 
     @Autowired
     private SecurityFilter securityFilter;
+    @Autowired
+    private CorsConfigurationSource corsConfigurationSource;
 
     // Filtro personalizado que valida tokens JWT antes del procesamiento de autenticación
 
@@ -46,9 +49,9 @@ public class SecurityConfiguration {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        return http
-                // Configuración de CORS usando la configuración por defecto
-                .cors(cors -> cors.configure(http))
+        http
+                // usar CorsConfigurationSource en la capa de seguridad
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 // Desactiva la protección CSRF
                 .csrf(AbstractHttpConfigurer::disable)
                 // Define que no se crearán sesiones HTTP
@@ -78,8 +81,8 @@ public class SecurityConfiguration {
                         )
                 )
                 // Inserta el filtro de seguridad JWT antes del filtro de autenticación por formularios
-                .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
-                .build();
+                .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
     }
 
     /**


### PR DESCRIPTION
📌 Cambios principales

- CORS unificado en Spring Security
- Se añadió un CorsConfigurationSource central para manejar orígenes permitidos (localhost, vercel.app, etc.).
- Se configuró SecurityConfiguration para usar ese CorsConfigurationSource.
- Ahora las peticiones OPTIONS (preflight) reciben 200 y devuelven los headers Access-Control-Allow-* correctos.
- SecurityFilter corregido.
- 
Ahora:
- SecurityConfiguration ajustada
- Permite OPTIONS /** para CORS.
- En SecurityFilter los errores (401, 403) ya no devuelven HTML de Tomcat, sino JSON válido.